### PR TITLE
Updates to AutoMapper 5.0

### DIFF
--- a/build/ShaneSpace.ProjectedDynamicLinq.nuspec
+++ b/build/ShaneSpace.ProjectedDynamicLinq.nuspec
@@ -2,16 +2,16 @@
 <package >
   <metadata>
     <id>ShaneSpace.ProjectedDynamicLinq</id>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
     <title>ShaneSpace.ProjectedDynamicLinq</title>
     <description>This is a modified copy of the Microsoft assembly for the .Net 4.0 Dynamic language functionality to work with Automapper and projections.</description>
     <authors>Shane Ray</authors>
     <owners>Shane Ray</owners>
     <projectUrl>https://github.com/shaneray/ShaneSpace.ProjectedDynamicLinq</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <copyright>Copyright 2015 Shane Ray</copyright>
+    <copyright>Copyright 2016 Shane Ray</copyright>
     <dependencies>
-      <dependency id="AutoMapper" version="3.3.1" />
+      <dependency id="AutoMapper" version="5.0.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/ShaneSpace.ProjectedDynamicLinq/ShaneSpace.ProjectedDynamicLinq.csproj
+++ b/src/ShaneSpace.ProjectedDynamicLinq/ShaneSpace.ProjectedDynamicLinq.csproj
@@ -30,11 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AutoMapper">
-      <HintPath>..\..\packages\AutoMapper.3.3.1\lib\net40\AutoMapper.dll</HintPath>
-    </Reference>
-    <Reference Include="AutoMapper.Net4">
-      <HintPath>..\..\packages\AutoMapper.3.3.1\lib\net40\AutoMapper.Net4.dll</HintPath>
+    <Reference Include="AutoMapper, Version=5.0.2.0, Culture=neutral, PublicKeyToken=be96cd2c38ef1005, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoMapper.5.0.2\lib\net45\AutoMapper.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -52,7 +50,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets" Condition="Exists('..\..\packages\AutoMapper.3.3.1\tools\AutoMapper.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/ShaneSpace.ProjectedDynamicLinq/packages.config
+++ b/src/ShaneSpace.ProjectedDynamicLinq/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoMapper" version="3.3.1" targetFramework="net45" />
+  <package id="AutoMapper" version="5.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
After 3.x there was a significant move to an instance based configuration
rather than a global configuration. 1.x of this library fails against the
latest version. This adds the ability to pass the current configuration in
as part of the query.

Because there are extra parameters I bumped this to a 2.0 release to
indicate the breaking change.
